### PR TITLE
Allow codecov to run `coverage xml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ script:
   - if [ $Cov == 'true'  ]; then py.test -vv --cov=./py_src/ ./py_src/; fi
   - if [ $Cov == 'false' ]; then py.test -vv; fi
 after_success:
-  - if [ $Cov == 'true'  ]; then python -m coverage combine; codecov --token=d89f9bd9-27a3-4560-8dbb-39ee3ba020a5 --file .coverage; fi
+  - if [ $Cov == 'true'  ]; then python -m coverage combine; codecov --token=d89f9bd9-27a3-4560-8dbb-39ee3ba020a5; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,4 +92,5 @@ build_script:
 
 on_success:
   - "%COV% combine"
+  - "%COV% xml"
   - "%RUN% -c \"import codecov; codecov.main(token='d89f9bd9-27a3-4560-8dbb-39ee3ba020a5')\""

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,4 +21,4 @@ build:
     - py.test -vv --cov=./py_src/ ./py_src/
   on_success:
     - coverage combine
-    - codecov --token=d89f9bd9-27a3-4560-8dbb-39ee3ba020a5 --file .coverage
+    - codecov --token=d89f9bd9-27a3-4560-8dbb-39ee3ba020a5


### PR DESCRIPTION
Codecov requires the xml output not the `.coverage` which is not a complete set of coverage results.

Thank you :)

> PS feel free to close this PR and update the document if you would like.